### PR TITLE
Fix callback query handler name error

### DIFF
--- a/handlers.py
+++ b/handlers.py
@@ -302,7 +302,7 @@ class TefillinHandlers:
 
     def get_conversation_handler(self):
         """יצירת ConversationHandler לזמן מותאם אישית"""
-        from telegram.ext import MessageHandler, filters, CommandHandler
+        from telegram.ext import MessageHandler, filters, CommandHandler, CallbackQueryHandler
         
         return ConversationHandler(
             entry_points=[CallbackQueryHandler(self.handle_custom_time_callback, pattern="time_custom")],


### PR DESCRIPTION
Add `CallbackQueryHandler` to imports to resolve `NameError` during deployment.

---
<a href="https://cursor.com/background-agent?bcId=bc-6a233e94-9a26-4e44-b17c-3b6022b8c215">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6a233e94-9a26-4e44-b17c-3b6022b8c215">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

