### PR TITLE
Deploy tefillin reminder bot

### DIFF
--- a/simple_health_server.py
+++ b/simple_health_server.py
@@ -119,13 +119,9 @@ def main():
     # Get port from environment
     port = int(os.environ.get("PORT", 10000))
 
-    # Start bot in background thread
+    # Start bot in background thread (do not delay HTTP server startup)
     bot_thread = Thread(target=run_telegram_bot, daemon=True)
     bot_thread.start()
-
-    # Give bot time to initialize
-    logger.info("Waiting for bot initialization...")
-    time.sleep(5)
 
     # Start Flask server (this blocks)
     logger.info(f"Starting health check server on port {port}...")

--- a/simple_health_server.py
+++ b/simple_health_server.py
@@ -86,6 +86,12 @@ def run_telegram_bot():
             bot_status["error"] = error_msg
             bot_status["last_update"] = datetime.now().isoformat()
 
+            # Standby (not leader)
+            if "Not leader" in str(e) or "leader lock" in str(e):
+                logger.info("Not leader. Standing by and retrying to acquire leader lock later...")
+                time.sleep(15)
+                continue
+
             # Check if it's a conflict error
             if "Conflict" in str(e) or "409" in str(e):
                 logger.warning("Conflict detected, waiting before retry...")


### PR DESCRIPTION
Implement a distributed leader lock and Telegram conflict error handler to prevent multiple bot instances from polling simultaneously.

The `409 Conflict` error indicates that multiple bot instances are attempting to `getUpdates` from Telegram with the same token, which is not allowed. This PR introduces a MongoDB-based leader lock to ensure only one instance actively polls for updates. Additionally, a conflict-aware error handler is added to gracefully log these conflicts, and the health server is adjusted to remain responsive even when an instance is in standby mode (not holding the leader lock).

---
<a href="https://cursor.com/background-agent?bcId=bc-acb7559a-9798-41d3-8dd9-e2287799c2a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-acb7559a-9798-41d3-8dd9-e2287799c2a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

