### PR TITLE
בדיקת הרשאות לפקודת שימוש

### DIFF
--- a/main_updated.py
+++ b/main_updated.py
@@ -9,24 +9,17 @@ from io import BytesIO
 
 from pymongo import MongoClient
 from telegram import (
-    InlineKeyboardButton,
-    InlineKeyboardMarkup,
     BotCommand,
     BotCommandScopeChat,
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
     KeyboardButton,
     ReplyKeyboardMarkup,
     Update,
     WebAppInfo,
 )
 from telegram.error import Conflict
-from telegram.ext import (
-    Application,
-    CallbackQueryHandler,
-    CommandHandler,
-    ContextTypes,
-    MessageHandler,
-    filters,
-)
+from telegram.ext import Application, CallbackQueryHandler, CommandHandler, ContextTypes, MessageHandler, filters
 
 from config import Config
 from database import DatabaseManager
@@ -694,7 +687,7 @@ class TefillinBot:
         try:
             admin_ids = getattr(Config, "ADMIN_IDS", []) or []
             if admin_ids:
-                commands = [BotCommand("usage", "דוח שימוש אחרון" )]
+                commands = [BotCommand("usage", "דוח שימוש אחרון")]
                 for admin_id in admin_ids:
                     try:
                         await self.app.bot.set_my_commands(commands, scope=BotCommandScopeChat(chat_id=admin_id))

--- a/main_updated.py
+++ b/main_updated.py
@@ -11,6 +11,8 @@ from pymongo import MongoClient
 from telegram import (
     InlineKeyboardButton,
     InlineKeyboardMarkup,
+    BotCommand,
+    BotCommandScopeChat,
     KeyboardButton,
     ReplyKeyboardMarkup,
     Update,
@@ -687,6 +689,20 @@ class TefillinBot:
 
         # עדכון זמני שקיעה
         await self.scheduler.update_daily_times()
+
+        # הגדרת תפריט פקודות ייעודי למנהלים בלבד (רק /usage) בצ'אט הפרטי שלהם
+        try:
+            admin_ids = getattr(Config, "ADMIN_IDS", []) or []
+            if admin_ids:
+                commands = [BotCommand("usage", "דוח שימוש אחרון" )]
+                for admin_id in admin_ids:
+                    try:
+                        await self.app.bot.set_my_commands(commands, scope=BotCommandScopeChat(chat_id=admin_id))
+                        logger.info(f"Admin commands set for chat {admin_id}")
+                    except Exception as e:
+                        logger.warning(f"Failed to set admin commands for chat {admin_id}: {e}")
+        except Exception as e:
+            logger.warning(f"Skipping admin commands configuration: {e}")
 
         logger.info("Bot startup completed successfully")
 

--- a/main_updated.py
+++ b/main_updated.py
@@ -565,11 +565,25 @@ class TefillinBot:
         results = self.db_manager.get_usage_last_days(days)
 
         if not results:
-            await update.message.reply_text(f"אין נתוני שימוש ב-{days} הימים האחרונים.")
+            summary = self.db_manager.get_usage_summary(days)
+            total_active = summary.get("total_active_users", 0)
+            users_done = summary.get("users_marked_done", 0)
+            total_marks = summary.get("total_marks", 0)
+            await update.message.reply_text(
+                "\n".join(
+                    [
+                        f"📊 סיכום שימוש {days} ימים אחרונים:",
+                        f"משתמשים פעילים: {total_active}",
+                        f"משתמשים שסימנו הנחה לפחות פעם אחת: {users_done}",
+                        f"מספר סימונים כולל (tefillin_done): {total_marks}",
+                        "(אין פירוט לפי משתמשים כי לא נמצאו לוגים מתאימים)",
+                    ]
+                )
+            )
             return
 
         total_users = len(results)
-        header = f'📊 שימוש ב-{days} ימים אחרונים\nסה"כ משתמשים פעילים: {total_users}\n\n'
+        header = f'📊 שימוש ב-{days} ימים אחרונים\nסה"כ משתמשים פעילים (עם לוגים): {total_users}\n\n'
 
         # בניית שורות תצוגה; הגבלת שעות לתצוגה עד 5 ראשונות
         lines = []


### PR DESCRIPTION
Add a general usage summary to the `/usage` command to provide information even when detailed logs are empty.

This change addresses the issue where the `/usage` command would report "no usage data" even if there was activity, by providing a high-level summary of active users and "tefillin_done" marks when detailed logs are unavailable.

---
<a href="https://cursor.com/background-agent?bcId=bc-27531129-9342-4910-b85a-4a55f5c95006">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-27531129-9342-4910-b85a-4a55f5c95006">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

