### PR TITLE
fix(render): drop startCommand for docker runtime

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -12,7 +12,6 @@ services:
     dockerfilePath: ./Dockerfile
     dockerContext: ./
 
-    startCommand: "/app/start.sh"
     healthCheckPath: "/health"
     autoDeploy: true
 


### PR DESCRIPTION
Dockerfile CMD already runs /app/start.sh; Render rejects startCommand on docker-runtime services.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified service startup configuration to use default behavior instead of a custom startup command.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/amirbiron/Tfilin/pull/13?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->